### PR TITLE
Disable plugin on twitter.com

### DIFF
--- a/twitter_client_urls.chromeextension/twitter_urls_to_clients.js
+++ b/twitter_client_urls.chromeextension/twitter_urls_to_clients.js
@@ -1,5 +1,9 @@
   // console.log(safari.extension.settings.client)
 
+ settings = {
+  "hostname_blacklist": ["twitter.com"]
+ }
+
  function change_twitter_to_clients() {
    var anchors = document.getElementsByTagName("a");
    for (var i = 0; i < anchors.length; i++ ){
@@ -20,7 +24,11 @@
      }
    }
  }
-  
+
+ function hostnameIsNotBlacklisted(hostname) {
+   return settings.hostname_blacklist.indexOf(hostname) == -1
+ }
+
  // We want to support dynamically added content so on every document change
  // do a quick check of the URLs. This will also most likely kick it to action initially.
 
@@ -29,7 +37,11 @@
      change_twitter_to_clients()
    });    
  });
-  
- var config = { attributes: true, childList: true, characterData: true, subtree: true };
- observer.observe(document.body, config);
- change_twitter_to_clients()
+
+ var hostname = new URL(document.URL).hostname
+
+ if (hostnameIsNotBlacklisted(hostname)) {
+   var config = { attributes: true, childList: true, characterData: true, subtree: true };
+   observer.observe(document.body, config);
+   change_twitter_to_clients()
+ };

--- a/twitter_client_urls.safariextension/twitter_urls_to_clients.js
+++ b/twitter_client_urls.safariextension/twitter_urls_to_clients.js
@@ -1,5 +1,9 @@
  // console.log(safari.extension.settings.client)
 
+settings = {
+  "hostname_blacklist": ["twitter.com"]
+}
+
 function change_twitter_to_clients() {
   var anchors = document.getElementsByTagName("a");
   for (var i = 0; i < anchors.length; i++ ){
@@ -20,7 +24,11 @@ function change_twitter_to_clients() {
     }
   }
 }
- 
+
+function hostnameIsNotBlacklisted(hostname) {
+  return settings.hostname_blacklist.indexOf(hostname) == -1
+}
+
 // We want to support dynamically added content so on every document change
 // do a quick check of the URLs. This will also most likely kick it to action initially.
 
@@ -29,7 +37,11 @@ var observer = new WebKitMutationObserver(function(mutations) {
     change_twitter_to_clients()
   });    
 });
- 
-var config = { attributes: true, childList: true, characterData: true, subtree: true };
-observer.observe(document.body, config);
-change_twitter_to_clients()
+
+var hostname = new URL(document.URL).hostname
+
+if (hostnameIsNotBlacklisted(hostname)) {
+  var config = { attributes: true, childList: true, characterData: true, subtree: true };
+  observer.observe(document.body, config);
+  change_twitter_to_clients()
+};


### PR DESCRIPTION
The plugin breaks the navigation on twitter.com itself, so i disabled it for that specific domain as I don't think that it is of any use there anyway? Tested in Safari and Chrome.
